### PR TITLE
support for definitions and device resolutions

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ function gs() {
       this.options.push('-dNOPAUSE');
       return this;
     },
+    "define": function(key, val) {
+      this.options.push('-d' + key + (val ? '=' + val : ''));
+      return this;
+    },
     "device": function(dev) {
       dev = dev || 'txtwrite';
       this.options.push('-sDEVICE=' + dev);
@@ -40,6 +44,10 @@ function gs() {
     "output": function(file) {
       file = file || '-';
       this.options.push('-sOutputFile=' + file);
+      return this;
+    },
+    "res": function(xres, yres) {
+      this.options.push('-r' + xres + (yres ? 'x' + yres : ''));
       return this;
     },
     "exec": function(cb) {

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -30,6 +30,14 @@ describe('gs', function() {
     assert.deepEqual(gs().input('file')._input, 'file');
     done();
   });
+  it('should set definition with value', function(done) {
+    assert.deepEqual(gs().define('FirstPage', 1).options, ['-dFirstPage=1']);
+    done();
+  });
+  it('should set device resolution', function(done) {
+    assert.deepEqual(gs().res(240, 72).options, ['-r240x72']);
+    done();
+  });
 
   describe('#exec', function() {
     it('should pass an error for no inputs', function(done) {


### PR DESCRIPTION
Awesome lib :beers: happy to of found it.

Needed a little more control for highres PDF conversion.

Couple of examples:

**define(key, value)** - defines a definition

```
gs()
  .batch()
  .output()
  .define('TextAlphaBits, 4)  // -dTextAlphaBits=4
  .define('GraphicsAlphaBits', 4)  // -dGraphicsAlphaBits=4
  .define('DownScaleFactor', 3)  // -dDownScaleFactor=3
  .exec(function(err, data) {
    console.log(data.toString());
  });
```

**res(xres, yres)** - sets device resolution

```
gs()
  .res(300, 72)  // -r300x72
  .batch()
  .output()
  .exec(function(err, data) {
    console.log(data.toString());
  });
```

_Added some basic tests for both as well._

---

Big thanks for putting **node-gs** together, much needed :ghost: ghostscript api for node.js :rocket: _(only one found on npm)_
