### PR TITLE
support for page count and PostScript commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ function gs() {
       this.options.push('-dNOPAUSE');
       return this;
     },
+    "command": function(cmd) {
+      this.options.push('-c', cmd.replace(/(\s)/g,'\ '));
+      return this;
+    },
     "define": function(key, val) {
       this.options.push('-d' + key + (val ? '=' + val : ''));
       return this;

--- a/index.js
+++ b/index.js
@@ -90,6 +90,16 @@ function gs() {
       process.on('exit', function() {
         proc.kill();
       });
+    },
+    "pagecount": function(cb) {
+      var self = this;
+      if (!this._input) return cb.call(self, 'No input specified');
+      this.q()
+        .command('(' + this._input + ') (r) file runpdfbegin pdfpagecount = quit')
+        .exec(function(err, data){
+          if (err) return cb.call(self, err);
+          return cb.call(self, null, data);
+        });
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -44,29 +44,29 @@ function gs() {
     "output": function(file) {
       file = file || '-';
       this.options.push('-sOutputFile=' + file);
-			if (file === '-') return this.q();
+      if (file === '-') return this.q();
       return this;
     },
-		"q": function() {
-			this.options.push('-q');
+    "q": function() {
+      this.options.push('-q');
       return this;
-		},
-		"p": function() {
-			this.options.push('-p');
+    },
+    "p": function() {
+      this.options.push('-p');
       return this;
-		},
-		"papersize": function(size) {
-			this.options.push('-sPAPERSIZE=' + size);
-			return this;
-		},
+    },
+    "papersize": function(size) {
+      this.options.push('-sPAPERSIZE=' + size);
+      return this;
+    },
     "res": function(xres, yres) {
       this.options.push('-r' + xres + (yres ? 'x' + yres : ''));
       return this;
     },
-		"safer": function() {
-			this.options.push('-dSAFER');
-			return this;
-		},
+    "safer": function() {
+      this.options.push('-dSAFER');
+      return this;
+    },
     "exec": function(cb) {
       var self = this;
       if (!this._input) return cb.call(self, 'No input specified');

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -90,4 +90,17 @@ describe('gs', function() {
         });
     });
   });
+
+  describe('#pagecount', function() {
+    it('should return number of pages', function(done) {
+      gs()
+        .input('./tests/pdfs/sizes.pdf')
+        .pagecount(function(err, count){
+          assert.ok(!err);
+          assert.equal(count, 3);
+
+          done();
+        })
+    });
+  });
 });

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -38,22 +38,22 @@ describe('gs', function() {
     assert.deepEqual(gs().res(240, 72).options, ['-r240x72']);
     done();
   });
-	it('should set the paper size', function(done) {
+  it('should set the paper size', function(done) {
     assert.deepEqual(gs().papersize('a4').options, ['-sPAPERSIZE=a4']);
     done();
-	});
-	it('should set gs to run in safe mode', function(done) {
+  });
+  it('should set gs to run in safe mode', function(done) {
     assert.deepEqual(gs().safer().options, ['-dSAFER']);
     done();
-	});
-	it('should tell gs to be quiet', function(done) {
-		assert.deepEqual(gs().q().options, ['-q']);
-		done();
-	});
-	it('should tell gs to use current directory for libraries first', function(done) {
-		assert.deepEqual(gs().p().options, ['-p']);
-		done();
-	});
+  });
+  it('should tell gs to be quiet', function(done) {
+    assert.deepEqual(gs().q().options, ['-q']);
+    done();
+  });
+  it('should tell gs to use current directory for libraries first', function(done) {
+    assert.deepEqual(gs().p().options, ['-p']);
+    done();
+  });
 
   describe('#exec', function() {
     it('should pass an error for no inputs', function(done) {

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -54,6 +54,10 @@ describe('gs', function() {
     assert.deepEqual(gs().p().options, ['-p']);
     done();
   });
+  it('should tell gs to interpret PostScript code', function(done) {
+    assert.deepEqual(gs().command('quit').options, ['-c', 'quit']);
+    done();
+  });
 
   describe('#exec', function() {
     it('should pass an error for no inputs', function(done) {


### PR DESCRIPTION
Nice to access to page counts without the extra dependency of [Xpdf's](http://www.foolabs.com/xpdf/download.html) `pdfinfo(1)`.

:ghost: Ghostscript can do this with a little PostScript magic...

**Added support for page count:**

---

**#pagecount(callback...)** - get number of pages

```
gs()
  .input('./test/pdfs/sizes.pdf')
  .pagecount(function(err, count){
    console.log('pages = ' + count);
  });
```

_Which is basically just a shortcut for `#command()` and `#exec()` that sends the PostScript page count code to gs_

---

**#command(cmd)** - tells Ghostscript to interpret PostScript code using `-c "code"`

```
gs()
  .q()
  .input('./test/pdfs/sizes.pdf')
  .command('(' + this._input + ') (r) file runpdfbegin pdfpagecount = quit')
  .exec(function(err, data){
    console.log('page count = ' + data);
  });
```

---

Tests included :beers:
