### PR TITLE
support for events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,107 +1,164 @@
-var spawn = require('child_process').spawn;
+var spawn = require('child_process').spawn,
+	EventEmitter = require('events').EventEmitter;
 
-function gs() {
-  return {
-    "options": [],
-    "_input": null,
-    "batch": function() {
-      this.options.push('-dBATCH');
-      return this;
-    },
-    "diskfonts": function() {
-      this.options.push('-dDISKFONTS');
-      return this;
-    },
-    "nobind": function() {
-      this.options.push('-dNOBIND');
-      return this;
-    },
-    "nocache": function() {
-      this.options.push('-dNOCACHE');
-      return this;
-    },
-    "nodisplay": function() {
-      this.options.push('-dNODISPLAY');
-      return this;
-    },
-    "nopause": function() {
-      this.options.push('-dNOPAUSE');
-      return this;
-    },
-    "command": function(cmd) {
-      this.options.push('-c', cmd.replace(/(\s)/g,'\ '));
-      return this;
-    },
-    "define": function(key, val) {
-      this.options.push('-d' + key + (val ? '=' + val : ''));
-      return this;
-    },
-    "device": function(dev) {
-      dev = dev || 'txtwrite';
-      this.options.push('-sDEVICE=' + dev);
-      return this;
-    },
-    "input": function(file) {
-      this._input = file;
-      return this;
-    },
-    "output": function(file) {
-      file = file || '-';
-      this.options.push('-sOutputFile=' + file);
-      if (file === '-') return this.q();
-      return this;
-    },
-    "q": function() {
-      this.options.push('-q');
-      return this;
-    },
-    "p": function() {
-      this.options.push('-p');
-      return this;
-    },
-    "papersize": function(size) {
-      this.options.push('-sPAPERSIZE=' + size);
-      return this;
-    },
-    "res": function(xres, yres) {
-      this.options.push('-r' + xres + (yres ? 'x' + yres : ''));
-      return this;
-    },
-    "safer": function() {
-      this.options.push('-dSAFER');
-      return this;
-    },
-    "exec": function(cb) {
-      var self = this;
-      if (!this._input) return cb.call(self, 'No input specified');
+module.exports = exports = create;
 
-      var proc = spawn('gs', this.options.concat([this._input]));
-      proc.stdin.on('error', cb);
-      proc.stdout.on('error', cb);
-
-      var _data = [];
-      var totalBytes = 0;
-      proc.stdout.on('data', function(data) { totalBytes += data.length; _data.push(data); });
-      proc.on('close', function() {
-        var buf = Buffer.concat(_data, totalBytes);
-
-        return cb.call(self, null, buf.toString());
-      });
-      process.on('exit', function() {
-        proc.kill();
-      });
-    },
-    "pagecount": function(cb) {
-      var self = this;
-      if (!this._input) return cb.call(self, 'No input specified');
-      this.q()
-        .command('(' + this._input + ') (r) file runpdfbegin pdfpagecount = quit')
-        .exec(function(err, data){
-          if (err) return cb.call(self, err);
-          return cb.call(self, null, data);
-        });
-    }
-  };
+function create() {
+	var _gs = new gs();
+	return _gs;
 }
 
-module.exports = exports = gs;
+function gs() {
+	this.options = [];
+	this._input = null;
+}
+
+gs.prototype.__proto__ = EventEmitter.prototype;
+
+gs.prototype.batch = function() {
+	this.options.push('-dBATCH');
+	return this;
+};
+
+gs.prototype.diskfonts = function() {
+	this.options.push('-dDISKFONTS');
+	return this;
+};
+
+gs.prototype.nobind = function() {
+	this.options.push('-dNOBIND');
+	return this;
+};
+
+gs.prototype.nocache = function() {
+	this.options.push('-dNOCACHE');
+	return this;
+};
+
+gs.prototype.nodisplay = function() {
+	this.options.push('-dNODISPLAY');
+	return this;
+};
+
+gs.prototype.nopause = function() {
+	this.options.push('-dNOPAUSE');
+	return this;
+};
+
+gs.prototype.command = function(cmd) {
+	this.options.push('-c', cmd.replace(/(\s)/g,'\ '));
+	return this;
+};
+
+gs.prototype.define = function(key, val) {
+	this.options.push('-d' + key + (val ? '=' + val : ''));
+	return this;
+};
+
+gs.prototype.device = function(dev) {
+	dev = dev || 'txtwrite';
+	this.options.push('-sDEVICE=' + dev);
+	return this;
+};
+
+gs.prototype.input = function(file) {
+	this._input = file;
+	return this;
+};
+
+gs.prototype.output = function(file) {
+	file = file || '-';
+	this.options.push('-sOutputFile=' + file);
+	if (file === '-') return this.q();
+	return this;
+};
+
+gs.prototype.quiet = function() {
+	this.options.push('-q');
+	return this;
+};
+
+gs.prototype.q = gs.prototype.quiet;
+
+gs.prototype.currentDirectory = function() {
+	this.options.push('-p');
+	return this;
+};
+
+gs.prototype.p = gs.prototype.currentDirectory;
+
+gs.prototype.papersize = function(size) {
+	this.options.push('-sPAPERSIZE=' + size);
+	return this;
+};
+
+gs.prototype.resolution = function(xres, yres) {
+	this.options.push('-r' + xres + (yres ? 'x' + yres : ''));
+	return this;
+};
+
+gs.prototype.res = gs.prototype.r = gs.prototype.resolution;
+
+gs.prototype.reset = function() {
+	this.options = [];
+	this._input = null;
+	return this;
+};
+
+gs.prototype.safer = function() {
+	this.options.push('-dSAFER');
+	return this;
+};
+
+gs.prototype.exec = function(cb) {
+	var self = this;
+	if (!this._input) return cb.call(self, 'No input specified');
+
+	var proc = spawn('gs', this.options.concat([this._input]));
+	proc.stdin.on('error', cb);
+	proc.stdout.on('error', cb);
+
+	var _data = [];
+	var totalBytes = 0;
+
+	proc.stdout.on('data', function(data) {
+		totalBytes += data.length;
+		_data.push(data);
+		var str = data.toString();
+
+		self.emit('data', data.toString());
+
+		if ( str.match(/Processing pages (.*) through (.*)\./) ) {
+			self.emit('pages', RegExp.$1, RegExp.$2);
+		}
+
+		if ( str.match(/Page (.*)/) ) {
+			self.emit('page', RegExp.$1);
+		}
+	});
+
+	proc.on('close', function() {
+		var buf = Buffer.concat(_data, totalBytes);
+
+		cb.call(self, null, buf.toString());
+		return self.emit('close');
+	});
+
+	process.on('exit', function() {
+		proc.kill();
+		self.emit('exit');
+	});
+};
+
+gs.prototype.pagecount = function(cb) {
+	var self = this;
+	if (!this._input) return cb.call(self, 'No input specified');
+
+	this.q()
+		.command('(' + this._input + ') (r) file runpdfbegin pdfpagecount = quit')
+		.exec(function(err, data){
+			if (err) return cb.call(self, err);
+			return cb.call(self, null, data);
+		});
+};
+

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -1,106 +1,195 @@
-var gs = require('../index'),
-    assert = require('assert');
+var gs = require('../index')
+		assert = require('assert');
 
 describe('gs', function() {
-  it('should set batch option', function(done) {
-    assert.deepEqual(gs().batch().options, ['-dBATCH']);
-    done();
-  });
-  it('should set nopause option', function(done) {
-    assert.deepEqual(gs().nopause().options, ['-dNOPAUSE']);
-    done();
-  });
-  it('should set device option with default', function(done) {
-    assert.deepEqual(gs().device().options, ['-sDEVICE=txtwrite']);
-    done();
-  });
-  it('should set device option with value', function(done) {
-    assert.deepEqual(gs().device('bacon').options, ['-sDEVICE=bacon']);
-    done();
-  });
-  it('should set output option with default', function(done) {
-    assert.deepEqual(gs().output().options, ['-sOutputFile=-', '-q']);
-    done();
-  });
-  it('should set output option with value', function(done) {
-    assert.deepEqual(gs().output('bacon').options, ['-sOutputFile=bacon']);
-    done();
-  });
-  it('should set inputs with file', function(done) {
-    assert.deepEqual(gs().input('file')._input, 'file');
-    done();
-  });
-  it('should set definition with value', function(done) {
-    assert.deepEqual(gs().define('FirstPage', 1).options, ['-dFirstPage=1']);
-    done();
-  });
-  it('should set device resolution', function(done) {
-    assert.deepEqual(gs().res(240, 72).options, ['-r240x72']);
-    done();
-  });
-  it('should set the paper size', function(done) {
-    assert.deepEqual(gs().papersize('a4').options, ['-sPAPERSIZE=a4']);
-    done();
-  });
-  it('should set gs to run in safe mode', function(done) {
-    assert.deepEqual(gs().safer().options, ['-dSAFER']);
-    done();
-  });
-  it('should tell gs to be quiet', function(done) {
-    assert.deepEqual(gs().q().options, ['-q']);
-    done();
-  });
-  it('should tell gs to use current directory for libraries first', function(done) {
-    assert.deepEqual(gs().p().options, ['-p']);
-    done();
-  });
-  it('should tell gs to interpret PostScript code', function(done) {
-    assert.deepEqual(gs().command('quit').options, ['-c', 'quit']);
-    done();
-  });
 
-  describe('#exec', function() {
-    it('should pass an error for no inputs', function(done) {
-      gs()
-        .batch()
-        .nopause()
-        .device()
-        .output()
-        .exec(function(err, data) {
-          assert.ok(err);
-          assert.ok(!this._input);
-          assert.equal(err, 'No input specified');
+	describe('#batch', function() {
+		it('should set batch option', function(done) {
+			assert.deepEqual(gs().batch().options, ['-dBATCH']);
+			done();
+		});
+	});
 
-          done();
-        });
-    });
-    it('should display data from a file', function(done) {
-      gs()
-        .batch()
-        .nopause()
-        .device()
-        .output()
-        .input('./tests/pdfs/sizes.pdf')
-        .exec(function(err, data) {
-          assert.ok(!err);
-          assert.equal(this._input, './tests/pdfs/sizes.pdf');
-          assert.equal(data, "               Normal\r\n           Envelope\r\n     Landscape\r\n");
+	describe('#nopause', function() {
+		it('should set nopause option', function(done) {
+			assert.deepEqual(gs().nopause().options, ['-dNOPAUSE']);
+			done();
+		});
+	});
 
-          done();
-        });
-    });
-  });
+	describe('#device', function() {
+		it('should set device option with default', function(done) {
+			assert.deepEqual(gs().device().options, ['-sDEVICE=txtwrite']);
+			done();
+		});
+		it('should set device option with value', function(done) {
+			assert.deepEqual(gs().device('bacon').options, ['-sDEVICE=bacon']);
+			done();
+		});
+	});
 
-  describe('#pagecount', function() {
-    it('should return number of pages', function(done) {
-      gs()
-        .input('./tests/pdfs/sizes.pdf')
-        .pagecount(function(err, count){
-          assert.ok(!err);
-          assert.equal(count, 3);
+	describe('#output', function() {
+		it('should set output option with default', function(done) {
+			assert.deepEqual(gs().output().options, ['-sOutputFile=-', '-q']);
+			done();
+		});
+		it('should set output option with value', function(done) {
+			assert.deepEqual(gs().output('bacon').options, ['-sOutputFile=bacon']);
+			done();
+		});
+	});
 
-          done();
-        })
-    });
-  });
+	describe('#input', function() {
+		it('should set inputs with file', function(done) {
+			assert.deepEqual(gs().input('file')._input, 'file');
+			done();
+		});
+	});
+
+	describe('#define', function() {
+		it('should set definition with value', function(done) {
+			assert.deepEqual(gs().define('FirstPage', 1).options, ['-dFirstPage=1']);
+			done();
+		});
+	});
+
+	describe('#resolution / #res / #r', function() {
+		it('should set device resolution', function(done) {
+			assert.deepEqual(gs().res(240, 72).options, ['-r240x72']);
+			done();
+		});
+	});
+
+	describe('#papersize', function() {
+		it('should set the paper size', function(done) {
+			assert.deepEqual(gs().papersize('a4').options, ['-sPAPERSIZE=a4']);
+			done();
+		});
+	});
+
+	describe('#safer', function() {
+		it('should set gs to run in safe mode', function(done) {
+			assert.deepEqual(gs().safer().options, ['-dSAFER']);
+			done();
+		});
+	});
+
+	describe('#quiet / #q', function() {
+		it('should tell gs to be quiet', function(done) {
+			assert.deepEqual(gs().q().options, ['-q']);
+			done();
+		});
+	});
+
+	describe('#currentDirectory / #p', function() {
+		it('should tell gs to use current directory for libraries first', function(done) {
+			assert.deepEqual(gs().p().options, ['-p']);
+			done();
+		});
+	});
+
+	describe('#command', function() {
+		it('should tell gs to interpret PostScript code', function(done) {
+			assert.deepEqual(gs().command('quit').options, ['-c', 'quit']);
+			done();
+		});
+	});
+
+	describe('#exec', function() {
+		it('should pass an error for no inputs', function(done) {
+			gs()
+				.batch()
+				.nopause()
+				.device()
+				.output()
+				.exec(function(err, data) {
+					assert.ok(err);
+					assert.ok(!this._input);
+					assert.equal(err, 'No input specified');
+
+					done();
+				});
+		});
+		it('should display data from a file', function(done) {
+			gs()
+				.batch()
+				.nopause()
+				.device()
+				.output()
+				.input('./tests/pdfs/sizes.pdf')
+				.exec(function(err, data) {
+					assert.ok(!err);
+					assert.equal(this._input, './tests/pdfs/sizes.pdf');
+					assert.equal(data, "               Normal\r\n           Envelope\r\n     Landscape\r\n");
+
+					done();
+				});
+		});
+	});
+
+	describe('#pagecount', function() {
+		it('should return number of pages', function(done) {
+			gs()
+				.input('./tests/pdfs/sizes.pdf')
+				.pagecount(function(err, count){
+					assert.ok(!err);
+					assert.equal(count, 3);
+
+					done();
+				})
+		});
+	});
+
+	describe('events', function() {
+		it('should emit `data` event', function(done) {
+			gs()
+				.q()
+				.nodisplay()
+				.input('./tests/pdfs/sizes.pdf')
+				.on('data', function(data) {
+					assert.equal(data, 'GS>');
+					done();
+				})
+				.exec(function(err, data){
+				});
+		});
+		it('should emit `pages` event', function(done) {
+			gs()
+				.input('./tests/pdfs/sizes.pdf')
+				.output('./test/pdfs/sizes-%d.jpg')
+				.on('pages', function(from, to) {
+					assert.equal(from, 1);
+					assert.equal(to, 3);
+
+					done();
+				})
+				.exec(function(err, data){
+				});
+		});
+		it('should emit `page` event', function(done) {
+			var count = 0;
+			gs()
+				.device('jpeg')
+				.output('tests/sizes-%d.jpg')
+				.batch()
+				.nopause()
+				.input('./tests/pdfs/sizes.pdf')
+				.on('page', function(page) {
+					if ( page ) count++;
+				})
+				.on('close', function() {
+					if ( count == 3 ) {
+						done();
+					}
+				})
+				.exec(function(err, data){
+				});
+		});
+		after(function(done){
+			require('child_process').exec('rm tests/sizes-*.jpg', function(err,stdout,stderr){
+				if (err) return done(err);
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Doing some work on calculating pdf conversion times :hourglass: progress complete, and needed some help from `EventEmitter`.

Didn't plan on this being such a large refactor to implement events, so **wanted to run it by you first** to get your thoughts.

Line-per-line a lot has changed but made sure the api and current functionality stayed exactly the same.

Let me know what you think  :eyes:

---

**#on(event, callback...)** - adds event listener to a `gs` instance

**Events:**
- `data` - emitted when data is received _(stdout)_
- `pages` - when page processing begins
- `page` - on **each** page process
### Examples

**.on('data', fn)** - callback gets `data` argument _(stdout)_

```
gs()
  .nodisplay()
  .input('./tests/pdfs/sizes.pdf')
  .on('data', function(data){
    console.log(data);
  })
  .exec(function(err, data){
    // do stuff...
  });
```

**.on('pages', fn)** - callback gets `from` _(first page)_ and `to` _(last page)_

```
gs()
  .input('./tests/pdfs/sizes.pdf')
  .output('./test/pdfs/sizes-%d.jpg')
  .on('pages', function(from, to) {
    console.log("processing pages %s to %s", from, to);
  })
  .exec(function(err, data){
    // do stuff...
  });
```

**.on('page', fn)** - callback gets `page` _(number of current page process)_ 

```
gs()
  .input('./tests/pdfs/sizes.pdf')
  .output('./test/pdfs/sizes-%d.jpg')
  .on('page', function(page) {
    console.log("page %s complete", page);
  })
  .exec(function(err, data){
    // do stuff...
  });
```

---

**Changed:**
- `gs` now inherits `EventEmitter`
- moved static methods to prototypes
- added aliases
  - `.p()` => `.currentDirectory()`
  - `.q()` => `.quiet()`
  - `.r()` and `.res()` => `.resolution()`
- added tests / updated test suits
- spaces to tabs globally

**Todo:**
- docs
- more examples

---

Really appreciate you putting this lib together, has been a major jump-start for me on new project and enjoy contributing back.
