### PR TITLE
Support for single page and page range processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,14 @@ gs.prototype.exec = function(cb) {
 	});
 };
 
+gs.prototype.page = function(page) {
+	return this.define('FirstPage', page).define('LastPage', page);
+};
+
+gs.prototype.pages = function(from, to) {
+	return this.define('FirstPage', from).define('LastPage', to);
+};
+
 gs.prototype.pagecount = function(cb) {
 	var self = this;
 	if (!this._input) return cb.call(self, 'No input specified');

--- a/tests/gs.js
+++ b/tests/gs.js
@@ -127,6 +127,40 @@ describe('gs', function() {
 		});
 	});
 
+	describe('#page', function() {
+		it('should tell gs to process single page', function(done) {
+			gs()
+				.nopause()
+				.input('./tests/pdfs/sizes.pdf')
+				.output('./test/pdfs/sizes-%d.jpg')
+				.page(2)
+				.on('pages', function(from, to){
+					assert.equal(from, 2);
+					assert.equal(to, 2);
+					done();
+				})
+				.exec(function(err, data){
+				});
+		});
+	});
+
+	describe('#pages', function() {
+		it('should tell gs to process page range', function(done) {
+			gs()
+				.nopause()
+				.input('./tests/pdfs/sizes.pdf')
+				.output('./test/pdfs/sizes-%d.jpg')
+				.pages(1, 2)
+				.on('pages', function(from, to){
+					assert.equal(from, 1);
+					assert.equal(to, 2);
+					done();
+				})
+				.exec(function(err, data){
+				});
+		});
+	});
+
 	describe('#pagecount', function() {
 		it('should return number of pages', function(done) {
 			gs()


### PR DESCRIPTION
Adds support for processing a specific page or range of pages to the api.

---

**#page(number)** - process a single page

```
gs()
  .nopause()
  .input('./tests/pdfs/sizes.pdf')
  .output('./test/pdfs/sizes-%d.jpg')
  .page(2)
  .on('page', function(page){
    console.log('page %s processed', page); // page 2 processed
  })
  .exec(function(err, data){
    // do stuff...
  });
```

**#pages(from, to)** - process a page range

```
gs()
  .nopause()
  .input('./tests/pdfs/sizes.pdf')
  .output('./test/pdfs/sizes-%d.jpg')
  .pages(2, 3)
  .on('pages', function(from, to){
    console.log('processing pages %s-%s', from, to); // processing pages 2-3
  })
  .exec(function(err, data){
    // do stuff...
  });
```

Both `.page()` and `.pages()` are basically just shortcuts for `gs` definitions. Using the `.define()` api it would looks something like this:

```
gs()
  .define('FirstPage', page)
  .define('LastPage', page)
```

_Tests included_

---

@ncb000gt let me know what you think. I'll merge and close this PR if it looks good by you :beers:
